### PR TITLE
[packaging] require droid-system and droid-system-vendor on obs builds. JB#42314

### DIFF
--- a/droid-hal-h4113.spec
+++ b/droid-hal-h4113.spec
@@ -42,6 +42,14 @@
 #define WANT_ADRENO_QUIRKS 1\
 %{nil}
 
+# Community builds may use the system partition for now
+%if 0%{?_obs_build_project:1}
+# On Android 8 the system partition is (intended to be) mounted on /.
+%define makefstab_skip_entries / /vendor
+Requires: droid-system
+Requires: droid-system-vendor
+%endif
+
 %include rpm/dhd/droid-hal-device.inc
 
 # IMPORTANT if you want to comment out any macros in your .spec, delete the %


### PR DESCRIPTION
[packaging] require droid-system and droid-system-vendor on obs builds. JB#42314

Signed-off-by: Franz-Josef Haider <franz.haider@jollamobile.com>